### PR TITLE
adding doc for debugging (kernel-debug & debug-driver)

### DIFF
--- a/debug/debug-driver
+++ b/debug/debug-driver
@@ -1,0 +1,67 @@
+
+                           HOW TO USE THE DEBUG-DRIVER
+
+=========================
+I. Driver presentation
+=========================
+
+Nanvix implements a debug-driver (src/kernel/debug), which will be initialized 
+only by selecting debug-mode in GRUB boot menu. 
+Then, each component can register debug function to this driver. 
+Just before end of boot, registered functions are executed, 
+then standard boot is resumed if each one were successful, and a kpanic is raised otherwise
+
+This drivers contains 3 main functions + 3 statistics functions: 
+
+    - void dbg_init(void): 
+        This function is called by kmain only if debug-mode had been selected in GRUB boot menu. 
+        If it's not executed (i.e. boot mode is standard mode), all functions of the driver will be skipped. 
+
+    - void dbg_register(debug_fn fn, char *fn_name): 
+        Each component has to call this function to register a test function. 
+        First parameter is a pointer on the function to register, which has to have a skeleton suiting debug_fn 
+        (i.e. return void and don't require any parameters) and second one is the name of this function. 
+        Name is important in order to make clear errors on failure.
+
+            | Example of call:
+            | dev.c implements a test for character devices named cdev_test 
+            | To register, it has to do: 
+            |     dbg_register(cdev_test, "cdev_test"); 
+            | in function dev_init 
+
+    - void dbg_execute(void): 
+        This function is called by kmain, and will execute all registered functions. 
+        It also prints statistics, and raises a kpanic if one or more functions fails 
+        (because failed debug-functions could create instabilities in the system). 
+        Otherwise, it waits for user to press Enter, then resume standard boot
+
+    - void tst_passed(void), void tst_failed(void), void tst_skipped(void): 
+        Used for statistics, one and only one has to be called within each debugging function
+
+===========================================
+II. How to write new debugging-functions
+===========================================
+
+Detailled examples are already implemented in nanvix, like in files dev.c, region.c, klog.c...
+
+But here's some tips for new debugging-functions: 
+
+    - Try to call dbg_register in the file where tests are implemented, in order to avoid useless
+      includes (because debug.h has to be included in these files) 
+
+    - Create a test main function, which returns void and takes no parameters (mandatory to be a debug_fn). 
+      In this function, just call sub-functions 1 by 1. 
+      These subfunctions should return 1 on success and 0 on failure. 
+      That way, test main function just has to execute tests, if one fails just do: 
+          tst_failed(); return;
+      and is all are successful, call tst_passed before last return. 
+
+    - Test sub-functions should test a really specific thing, 
+      and use log_level when calling kprintf makes logs easier to read.
+      It's possible to use kprintf with log_levels as warnings, errors, infos (detailed list is in klib.h).
+      Whenever something went wrong, use imediately:
+            kprintf([KERN_LOG_LEVEL][specific error message]; return 0;
+
+    - All tests should, when fully executed, completely restore the state of the system. 
+      (For example, test in regions.c, which allocate memory regions, frees the regions before ending). 
+      That way, normal boot can continue after tests.

--- a/debug/kernel-debug
+++ b/debug/kernel-debug
@@ -1,0 +1,89 @@
+
+                           EARLY BOOT & KERNEL DEBUGGING
+
+==================================
+I. Debug standard kernel files
+==================================
+
+A script had been created in order to attach GDB debugguer to QEMU with the GUI DDD.
+You can execute it with the classic launching command with the --dbg argument
+
+    sudo bash tools/run/run-qemu.sh --dbg
+
+    | What is hidden behind this script is this bash command: 
+    |   bash  qemu-system-i386 -s -S -drive file=nanvix.iso, format=raw,
+    |   if=ide, media=cdrom -m 256M -mem-prealloc & ddd --debugger "/usr/
+    |   locals/cross/bin/i386-elf-gdb" 
+    | There are 3 main differencies applied to the command by passing argument --dbg: 
+    |   - -s: Makes QEMU to listen on TCP Port 1234 
+    |   - -S: QEMU won't execute anything until it receives the former order continue 
+    |   - ddd --debugger [...]: Launch DDD GUI using GDB.
+
+DDD will automatically makes GDB to attach on QEMU process.
+
+Within DDD, a view of UTILITIES.S script file is provided, so it's easy to debug this file using GUI only. 
+(Doucle-click on the line to create a breakpoint).
+
+Other files debuggable are the ones included in src/kernel (nanvix's kernel),
+and it's possible to creates breakpoints within theses files with the GDB command:
+
+    b src/kernel/[rest of the path]:[line number]
+
+Then, here's some useful GDB's commands:
+    - c: will make QEMU to continue until it reaches the breakpoint. 
+    - s: step into
+         (for example, if current line is kprintf, this will stops the execution at the beginning of kprintf function) 
+    - n: step over
+         (if current line is kprintf, this will execute it and stops execution at the next line in your current file)
+
+To properly debug assembly code, there is specific command:
+    - stepi: can be used to go step by step into an assembly file. 
+
+It's possible to see assembly execution stack with the MACHINE CODE WINDOW (Alt+4 to enable/disable). 
+Assembly code uses a lot of addresses. You can view the content at a given address with this command:
+
+    x /10sb [address] (address must be in hexa)
+
+It's easy to get info on both args and local variables with commands (respectively): 
+	
+    info args
+    info locals 
+
+    | These info are also accessible within the GUI with commands (respectively): Alt+U & Alt+L
+
+==================================================
+II. Debug early boot files (Specifically boot.S)
+==================================================
+
+Some files, even in the kernel, are loaded in a restricted area of the memory, and GDB can't have a direct access to it.
+
+You can't directly see it in the editor, 
+but it's still possible to debug using DDD and GDB by putting a breakpoint on a FUNCTION NAME. 
+
+    | For example, if you want to debug assembly function start in boot.S, use the command: 
+    |   b start 
+    | Then boot.S code is going to be accessible through MACHINE CODE WINDOW
+
+=========================
+III. Kernel log format
+=========================
+
+One useful way of debugging kernel is to use KERNEL LOGS. 
+
+When kprintf is called during execution, a klog entry is also added. 
+The klog is accessible in /dev/klog, and you can view the file using cat for example: 
+
+    cat /dev/klog 
+
+Entries of this file contains also some further information, and are following this format:
+
+    [LOG_LEVEL]: [CLOCKS TICKS]: LOG ENTRY
+
+    [OPTIONNAL] 
+    1) LOG_LEVEL: A digit within [1..7], representing what is the level of this log entry. Levels are lister in klib.h 
+
+    [IF LOG_LEVEL IS DEFINED] 
+    2) CLOCKS TICKS: A signed int representing the number of clocks ticks elapsed since initialization 
+                     to the moment the entry is added 
+
+    3) LOG ENTRY


### PR DESCRIPTION
2 doc files for debugging nanvix's kernel, plain-text format:

   1) kernel-debug: 
          Little tuto, written for non-users of GDB tool. Explain how to attach GDB to nanvix, list useful commands. Also explain how to use log levels.

   2) debug-driver:
          Explain how to use debug-driver.